### PR TITLE
Add render pass annotations

### DIFF
--- a/Engine/Graphics/DebugDraw.cpp
+++ b/Engine/Graphics/DebugDraw.cpp
@@ -140,6 +140,8 @@ namespace Bat
 	void DebugDraw::Flush( const Camera& camera )
 	{
 		IGPUContext* pContext = gpu->GetContext();
+		pContext->BeginEvent( "debug_draw" );
+
 		InitDebugDrawState( pContext );
 
 		for( const DebugRect& rect : g_DebugRects )
@@ -169,5 +171,7 @@ namespace Bat
 
 			g_DebugTexts.clear();
 		}
+
+		pContext->EndEvent();
 	}
 }

--- a/Engine/Graphics/Graphics.cpp
+++ b/Engine/Graphics/Graphics.cpp
@@ -157,12 +157,20 @@ namespace Bat
 
 	void Graphics::RenderUI()
 	{
+		IGPUContext* pContext = gpu->GetContext();
+
+		pContext->BeginEvent( "ultralight ui" );
 		m_UI.Update();
 		m_UI.Render();
+		pContext->EndEvent();
 	}
 
 	void Graphics::RenderImGui()
 	{
+		IGPUContext* pContext = gpu->GetContext();
+
+		pContext->BeginEvent( "imgui" );
+
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData( ImGui::GetDrawData() );
 
@@ -172,5 +180,7 @@ namespace Bat
 			ImGui::UpdatePlatformWindows();
 			ImGui::RenderPlatformWindowsDefault();
 		}
+
+		pContext->EndEvent();
 	}
 }

--- a/Engine/Graphics/IGPUDevice.h
+++ b/Engine/Graphics/IGPUDevice.h
@@ -85,6 +85,8 @@ namespace Bat
 		virtual void* GetImpl() = 0;
 	};
 
+	using GraphicsEventHandle_t = uintptr_t;
+
 	class IGPUContext
 	{
 	public:
@@ -186,6 +188,9 @@ namespace Bat
 
 		virtual void Draw( size_t vertex_count ) = 0;
 		virtual void DrawIndexed( size_t index_count ) = 0;
+
+		virtual void BeginEvent( const std::string& name ) = 0;
+		virtual void EndEvent() = 0;
 
 		// Gets pointer to underlying implementation
 		// e.g. for D3D11 device this returns the ID3D11DeviceContext*

--- a/Engine/Graphics/RenderGraph.h
+++ b/Engine/Graphics/RenderGraph.h
@@ -21,6 +21,7 @@ namespace Bat
 	public:
 		void AddPass( const std::string& name, std::unique_ptr<IRenderPass> pass );
 		size_t GetPassCount() const;
+		std::string GetPassNameByIndex( size_t idx );
 		IRenderPass* GetPassByIndex( size_t idx );
 		IRenderPass* GetPassByName( const std::string& name );
 		int GetPassIndexByName( const std::string& name );
@@ -76,6 +77,7 @@ namespace Bat
 	private:
 		// passes
 		std::vector<std::unique_ptr<IRenderPass>> m_vRenderPasses;
+		std::vector<std::string> m_vPassNames;
 		std::unordered_map<std::string, size_t> m_mapPassNameToIndex;
 		std::vector<bool> m_vPassEnabled;
 		std::optional<Node_t> m_OutputNode;


### PR DESCRIPTION
They show up in graphics debugger and group together the draw calls into their relevant pass, making it a lot easier to look through.

![Example output](https://cdn.discordapp.com/attachments/204275860226703360/649987096085397504/unknown.png)