### PR TITLE
Fix regressions

### DIFF
--- a/Engine/Graphics/IGPUDevice.h
+++ b/Engine/Graphics/IGPUDevice.h
@@ -183,7 +183,7 @@ namespace Bat
 		virtual void UpdateTexturePixels( ITexture* pTexture, const void* pPixels, size_t pitch ) = 0;
 		virtual void BindTexture( ITexture* pTexture, size_t slot ) = 0;
 		virtual void BindTexture( IRenderTarget* pRT, size_t slot ) = 0;
-		virtual void BindTexture( IDepthStencil* pDepthStencil, size_t slot, size_t index = 0 ) = 0;
+		virtual void BindTexture( IDepthStencil* pDepthStencil, size_t slot ) = 0;
 		virtual void UnbindTextureSlot( size_t slot ) = 0;
 
 		// Update the vertex buffer with the given data

--- a/Engine/Graphics/Shaders/SkyboxPS.hlsl
+++ b/Engine/Graphics/Shaders/SkyboxPS.hlsl
@@ -10,5 +10,5 @@ struct PixelInputType
 
 float4 main(PixelInputType input) : SV_TARGET
 {
-    return SkyboxTexture.Sample(WrapSampler, input.tex);
+    return ToLinearSpace(SkyboxTexture.Sample(WrapSampler, input.tex));
 }


### PR DESCRIPTION
Skybox texture sample wasn't being converted to linear space, but was still being converted to sRGB space in the tonemapping post-process. This lead to a washed out colour for the skybox.

When implementing MSAA, a bug was introduced that caused depth-stencil array SRVs to not be bound correctly, causing shadow maps to not function correctly.